### PR TITLE
docs: updated install documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,13 +31,13 @@ First, [install Ape](https://docs.apeworx.io/ape/stable/userguides/quickstart.ht
 Second, make sure to install the plugins:
 
 ```sh
-$ ape plugins install .
+$ ape plugins install . --upgrade
 ```
 
 Lastly, since this is an SDK package, install the SDK:
 
 ```sh
-$ poetry install .
+$ poetry install
 ```
 
 Then you are ready to contribute!


### PR DESCRIPTION
updated documentation to resolve the following issues with installation:

```
$ ape plugins install .
WARNING: 'vyper' is already installed. Did you mean to include '--upgrade'.
```
```
$ poetry install .
No arguments expected for "install" command, got "."
```