### PR TITLE
fix(contracts): syntax error in ABI input argument name

### DIFF
--- a/contracts/Validator.json
+++ b/contracts/Validator.json
@@ -1,18 +1,16 @@
 {
-    "abi": [
-        {
-            "name": "validate",
-            "type": "function",
-            "inputs": [
-                {"name": "creator", "type": "address"},
-                {"name": "token: ", "type": "address"},
-                {"name": "amount_per_second", "type": "uint256"},
-                {"name": "reason", "type": "bytes"}
-            ],
-            "outputs": [
-                {"name": "max_stream_life", "type": "uint256"}
-            ],
-            "stateMutability": "nonpayable"
-        }
-    ]
+  "abi": [
+    {
+      "name": "validate",
+      "type": "function",
+      "stateMutability": "nonpayable",
+      "inputs": [
+        { "name": "creator", "type": "address" },
+        { "name": "token", "type": "address" },
+        { "name": "amount_per_second", "type": "uint256" },
+        { "name": "reason", "type": "bytes" }
+      ],
+      "outputs": [{ "name": "max_stream_life", "type": "uint256" }]
+    }
+  ]
 }


### PR DESCRIPTION
arg 2 was called `"token: "` and not `"token"`