### PR TITLE
fix: time_left max C int issue [SBK-338]

### DIFF
--- a/sdk/py/apepay/__init__.py
+++ b/sdk/py/apepay/__init__.py
@@ -27,10 +27,9 @@ from .exceptions import (
     TokenNotAccepted,
     ValidatorFailed,
 )
-from .settings import Settings
 from .utils import time_unit_to_timedelta
 
-settings = Settings()
+MAX_DURATION_SECONDS = int(timedelta.max.total_seconds()) - 1
 
 
 class Validator(BaseInterfaceModel):
@@ -431,11 +430,7 @@ class Stream(BaseInterfaceModel):
     @property
     def time_left(self) -> timedelta:
         seconds = self.contract.time_left(self.creator, self.stream_id)
-        return timedelta(
-            seconds=settings.MAX_STREAM_DURATION
-            if seconds > settings.MAX_STREAM_DURATION
-            else seconds
-        )
+        return timedelta(seconds=min(MAX_DURATION_SECONDS, seconds))
 
     @property
     def total_time(self) -> timedelta:
@@ -447,11 +442,7 @@ class Stream(BaseInterfaceModel):
             # NOTE: `last_pull == start_time` if never pulled
             datetime.fromtimestamp(info.last_pull)
             - datetime.fromtimestamp(info.start_time)
-            + timedelta(
-                seconds=settings.MAX_STREAM_DURATION
-                if max_life > settings.MAX_STREAM_DURATION
-                else max_life
-            )
+            + timedelta(seconds=min(MAX_DURATION_SECONDS, max_life))
         )
 
     @property

--- a/sdk/py/apepay/__init__.py
+++ b/sdk/py/apepay/__init__.py
@@ -27,7 +27,10 @@ from .exceptions import (
     TokenNotAccepted,
     ValidatorFailed,
 )
+from .settings import Settings
 from .utils import time_unit_to_timedelta
+
+settings = Settings()
 
 
 class Validator(BaseInterfaceModel):
@@ -427,17 +430,28 @@ class Stream(BaseInterfaceModel):
 
     @property
     def time_left(self) -> timedelta:
-        return timedelta(seconds=self.contract.time_left(self.creator, self.stream_id))
+        seconds = self.contract.time_left(self.creator, self.stream_id)
+        return timedelta(
+            seconds=settings.MAX_STREAM_DURATION
+            if seconds > settings.MAX_STREAM_DURATION
+            else seconds
+        )
 
     @property
     def total_time(self) -> timedelta:
         info = self.info  # NOTE: Avoid calling contract twice
+        # NOTE: Measure time-duration of unclaimed amount remaining (locked and unlocked)
+        max_life = int(info.funded_amount / info.amount_per_second)
+
         return (
             # NOTE: `last_pull == start_time` if never pulled
             datetime.fromtimestamp(info.last_pull)
             - datetime.fromtimestamp(info.start_time)
-            # NOTE: Measure time-duration of unclaimed amount remaining (locked and unlocked)
-            + timedelta(seconds=int(info.funded_amount / info.amount_per_second))
+            + timedelta(
+                seconds=settings.MAX_STREAM_DURATION
+                if max_life > settings.MAX_STREAM_DURATION
+                else max_life
+            )
         )
 
     @property

--- a/sdk/py/apepay/settings.py
+++ b/sdk/py/apepay/settings.py
@@ -8,6 +8,7 @@ from pydantic import BaseSettings, validator
 class Settings(BaseSettings):
     WARNING_LEVEL: timedelta = timedelta(days=2)
     CRITICAL_LEVEL: timedelta = timedelta(hours=12)
+    MAX_STREAM_DURATION: int = int(timedelta.max.total_seconds()) - 1
 
     @validator("WARNING_LEVEL", "CRITICAL_LEVEL", pre=True)
     def _normalize_timedelta(cls, value: Any) -> timedelta:

--- a/sdk/py/apepay/settings.py
+++ b/sdk/py/apepay/settings.py
@@ -8,7 +8,6 @@ from pydantic import BaseSettings, validator
 class Settings(BaseSettings):
     WARNING_LEVEL: timedelta = timedelta(days=2)
     CRITICAL_LEVEL: timedelta = timedelta(hours=12)
-    MAX_STREAM_DURATION: int = int(timedelta.max.total_seconds()) - 1
 
     @validator("WARNING_LEVEL", "CRITICAL_LEVEL", pre=True)
     def _normalize_timedelta(cls, value: Any) -> timedelta:


### PR DESCRIPTION
This prevents the python sdk from attempting to overflow when instantiating timedeta objects with exceptionally long-funded streams.  The effective limit is like 220k years so even though the accuracy is reduced, humanity will probably have ascended to the stars by that point.

Fixes #65