### PR TITLE
set default token in CreateStream

### DIFF
--- a/ui/lib/CreateStream.tsx
+++ b/ui/lib/CreateStream.tsx
@@ -229,15 +229,21 @@ const CreateStream = (props: CreateStreamProps) => {
   };
 
   // Get your current chainID
-  let targetChainId: number | undefined;
-  if (chain) {
-    targetChainId = chain.id;
-  }
+  const targetChainId = chain ? chain.id : undefined;
 
-  // reset selectedToken if chainId changes
   useEffect(() => {
+    // Reset the selectedToken when the targetChainId changes
     setSelectedToken(null);
-  }, [targetChainId]);
+
+    // Filter the tokens based on the chainId
+    const filteredTokens = props.tokenList.filter((token) => token.chainId === targetChainId);
+
+    // If there's only one token, set it as the selected token
+    if (filteredTokens.length === 1) {
+      setSelectedToken(filteredTokens[0]);
+    }
+
+  }, [props.tokenList, targetChainId]);
 
   // Select the payment token among tokens with the same chainID
   const Step1 = () => {

--- a/ui/lib/CreateStream.tsx
+++ b/ui/lib/CreateStream.tsx
@@ -236,13 +236,14 @@ const CreateStream = (props: CreateStreamProps) => {
     setSelectedToken(null);
 
     // Filter the tokens based on the chainId
-    const filteredTokens = props.tokenList.filter((token) => token.chainId === targetChainId);
+    const filteredTokens = props.tokenList.filter(
+      (token) => token.chainId === targetChainId,
+    );
 
     // If there's only one token, set it as the selected token
     if (filteredTokens.length === 1) {
       setSelectedToken(filteredTokens[0]);
     }
-
   }, [props.tokenList, targetChainId]);
 
   // Select the payment token among tokens with the same chainID


### PR DESCRIPTION
The dropdown makes sense when you have multiple tokens to pick from.

If you only have one token, make it so that the dropdown displays this option by default.

PR suggested by Mike: allows for a smoother payment UX and a faster payment.

![Screenshot 2023-12-15 at 15 05 25](https://github.com/ApeWorX/ApePay/assets/117547827/d00808af-3b97-491e-9cb1-95b3e19e2a98)
