### PR TITLE
fix: bug with cancelling

### DIFF
--- a/contracts/StreamManager.vy
+++ b/contracts/StreamManager.vy
@@ -219,14 +219,14 @@ def cancel_stream(
     reason: Bytes[MAX_REASON_SIZE] = b"",
     creator: address = msg.sender,
 ) -> uint256:
-    assert msg.sender in [creator, self.owner]
+    assert msg.sender == creator or msg.sender == self.owner
     assert self.streams[creator][stream_id].start_time + MIN_STREAM_LIFE <= block.timestamp
 
     funded_amount: uint256 = self.streams[creator][stream_id].funded_amount
     amount_locked: uint256 = funded_amount  - self._amount_unlocked(creator, stream_id)
 
     token: ERC20 = self.streams[creator][stream_id].token
-    assert token.transfer(msg.sender, amount_locked, default_return_value=True)
+    assert token.transfer(creator, amount_locked, default_return_value=True)
 
     self.streams[creator][stream_id].funded_amount = funded_amount - amount_locked
 


### PR DESCRIPTION
Would allow the `owner` to be able to "steal" the unvested funds of a stream being cancelled