### PR TITLE
fix(contract): bug with ordering of operations

### DIFF
--- a/contracts/StreamManager.vy
+++ b/contracts/StreamManager.vy
@@ -224,6 +224,7 @@ def cancel_stream(
 
     funded_amount: uint256 = self.streams[creator][stream_id].funded_amount
     amount_locked: uint256 = funded_amount - self._amount_unlocked(creator, stream_id)
+    assert amount_locked > 0  # NOTE: reverts if stream doesn't exist, or already cancelled
     self.streams[creator][stream_id].funded_amount = funded_amount - amount_locked
 
     token: ERC20 = self.streams[creator][stream_id].token

--- a/contracts/StreamManager.vy
+++ b/contracts/StreamManager.vy
@@ -219,8 +219,12 @@ def cancel_stream(
     reason: Bytes[MAX_REASON_SIZE] = b"",
     creator: address = msg.sender,
 ) -> uint256:
-    assert msg.sender == creator or msg.sender == self.owner
-    assert self.streams[creator][stream_id].start_time + MIN_STREAM_LIFE <= block.timestamp
+    if msg.sender == creator:
+        # Creator needs to wait `MIN_STREAM_LIFE` to cancel a stream
+        assert self.streams[creator][stream_id].start_time + MIN_STREAM_LIFE <= block.timestamp
+    else:
+        # Owner can cancel at any time
+        assert msg.sender == self.owner
 
     funded_amount: uint256 = self.streams[creator][stream_id].funded_amount
     amount_locked: uint256 = funded_amount - self._amount_unlocked(creator, stream_id)

--- a/sdk/py/apepay/__init__.py
+++ b/sdk/py/apepay/__init__.py
@@ -24,7 +24,6 @@ from .exceptions import (
     FundsNotClaimable,
     MissingCreationReceipt,
     StreamLifeInsufficient,
-    StreamNotCancellable,
     TokenNotAccepted,
     ValidatorFailed,
 )
@@ -460,9 +459,6 @@ class Stream(BaseInterfaceModel):
 
     @property
     def cancel(self) -> ContractTransactionHandler:
-        if not self.is_cancelable:
-            raise StreamNotCancellable(self.time_left)
-
         return cast(
             ContractTransactionHandler,
             partial(self.contract.cancel_stream, self.stream_id),

--- a/sdk/py/apepay/__init__.py
+++ b/sdk/py/apepay/__init__.py
@@ -421,7 +421,7 @@ class Stream(BaseInterfaceModel):
         return self.contract.amount_unlocked(self.creator, self.stream_id)
 
     @property
-    def amount_left(self) -> int:
+    def amount_locked(self) -> int:
         return self.info.funded_amount - self.amount_unlocked
 
     @property

--- a/sdk/py/apepay/exceptions.py
+++ b/sdk/py/apepay/exceptions.py
@@ -14,11 +14,6 @@ class MissingCreationReceipt(ApePayException, NotImplementedError):
         super().__init__("Missing creation transaction for stream. Functionality unavailabie.")
 
 
-class StreamNotCancellable(ApePayException):
-    def __init__(self, time_left: timedelta):
-        super().__init__(f"Stream not cancelable yet. Please wait: {time_left}")
-
-
 class FundsNotClaimable(ApePayException):
     def __init__(self):
         super().__init__("Stream has no funds left to claim.")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,6 +25,20 @@ def tokens(create_token, payer, request):
 
 
 @pytest.fixture(scope="session")
+def token(tokens):
+    if len(tokens) == 0:
+        pytest.skip("No valid tokens")
+
+    return tokens[0]
+
+
+@pytest.fixture(scope="session")
+def starting_balance(token, payer):
+    # NOTE: All tokens start with the same balance
+    return token.balanceOf(payer)
+
+
+@pytest.fixture(scope="session")
 def create_validator(owner, project):
     def create_validator():
         return owner.deploy(project.TestValidator)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,6 @@
 import pytest
 from apepay import StreamManager
 
-ONE_HOUR = 60 * 60
-
-
 @pytest.fixture(scope="session")
 def owner(accounts):
     return accounts[0]
@@ -41,8 +38,13 @@ def validators(create_validator, request):
 
 
 @pytest.fixture(scope="session")
-def stream_manager_contract(owner, project, validators, tokens):
-    return owner.deploy(project.StreamManager, owner, ONE_HOUR, validators, tokens)
+def MIN_STREAM_LIFE():
+    return 60 * 60  # 1 hour in seconds
+
+
+@pytest.fixture(scope="session")
+def stream_manager_contract(owner, project, MIN_STREAM_LIFE, validators, tokens):
+    return owner.deploy(project.StreamManager, owner, MIN_STREAM_LIFE, validators, tokens)
 
 
 @pytest.fixture(scope="session")

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,4 +1,5 @@
 from datetime import datetime, timedelta
+import ape
 
 import pytest
 from apepay import exceptions as apepay_exc
@@ -7,7 +8,6 @@ from apepay import exceptions as apepay_exc
 def test_init(stream_manager, owner, validators, tokens):
     assert stream_manager.MIN_STREAM_LIFE == timedelta(hours=1)
     assert stream_manager.owner == owner
-
     assert stream_manager.validators == validators
 
     for token in tokens:
@@ -16,31 +16,45 @@ def test_init(stream_manager, owner, validators, tokens):
 
 def test_set_validators(stream_manager, owner, create_validator):
     new_validator = create_validator()
-
     assert new_validator not in stream_manager.validators
 
     stream_manager.add_validators(new_validator, sender=owner)
-
     assert new_validator in stream_manager.validators
 
     stream_manager.remove_validators(new_validator, sender=owner)
-
     assert new_validator not in stream_manager.validators
 
 
 def test_add_rm_tokens(stream_manager, owner, tokens, create_token):
     new_token = create_token(owner)
     assert new_token not in tokens
-
     assert not stream_manager.is_accepted(new_token)
 
     stream_manager.add_token(new_token, sender=owner)
-
     assert stream_manager.is_accepted(new_token)
 
     stream_manager.remove_token(new_token, sender=owner)
-
     assert not stream_manager.is_accepted(new_token)
+
+
+@pytest.fixture(scope="session")
+def create_stream(stream_manager, payer, MIN_STREAM_LIFE):
+    def create_stream(token=None, amount_per_second=None, sender=None, allowance=(2**256-1), **extra_args):
+        if amount_per_second is None:
+            # NOTE: Maximum amount we can afford to send (using 1 hr pre-allocation)
+            amount_per_second = token.balanceOf(sender or payer) // MIN_STREAM_LIFE
+
+        if token.allowance(sender or payer, stream_manager.contract) != allowance:
+            token.approve(stream_manager.contract, allowance, sender=sender or payer)
+
+        return stream_manager.create(
+            token,
+            amount_per_second,
+            **extra_args,
+            sender=sender or payer,
+        )
+
+    return create_stream
 
 
 @pytest.mark.parametrize(
@@ -58,31 +72,24 @@ def test_add_rm_tokens(stream_manager, owner, tokens, create_token):
         dict(start_time=-1000),
     ],
 )
-def test_create_stream(chain, payer, tokens, stream_manager, extra_args):
-    if len(tokens) == 0:
-        pytest.skip("No valid tokens")
+def test_create_stream(chain, payer, token, create_stream, MIN_STREAM_LIFE, extra_args):
+    with pytest.raises(apepay_exc.StreamLifeInsufficient):
+        create_stream(token, allowance=0, **extra_args)
 
-    # NOTE: Maximum amount we can afford to send (using 1 hr pre-allocation)
-    amount_per_second = tokens[0].balanceOf(payer) // int(
-        stream_manager.MIN_STREAM_LIFE.total_seconds()
-    )
+    amount_per_second = (token.balanceOf(payer) // MIN_STREAM_LIFE)
 
     with pytest.raises(apepay_exc.StreamLifeInsufficient):
-        stream_manager.create(tokens[0], amount_per_second, sender=payer)
+        # NOTE: Performs approval
+        create_stream(token, amount_per_second=amount_per_second + 1, **extra_args)
 
-    tokens[0].approve(stream_manager.contract, 2**256 - 1, sender=payer)
-
-    with pytest.raises(apepay_exc.StreamLifeInsufficient):
-        stream_manager.create(tokens[0], amount_per_second + 1, sender=payer)
-
-    stream = stream_manager.create(tokens[0], amount_per_second, **extra_args, sender=payer)
+    stream = create_stream(token, **extra_args)
     start_time = chain.blocks.head.timestamp
 
-    assert stream.token == tokens[0]
+    assert stream.token == token
     assert stream.stream_id == 0
     assert stream.creator == payer
     assert stream.amount_per_second == amount_per_second
     assert stream.reason == extra_args.get("reason", "")
+
     expected = datetime.fromtimestamp(start_time + extra_args.get("start_time", 0))
-    one_second = timedelta(seconds=1)
-    assert stream.start_time - expected <= one_second, "Unexpected start time"
+    assert stream.start_time - expected <= timedelta(seconds=1), "Unexpected start time"


### PR DESCRIPTION
There was a bug in the StreamManager implementation concerning some order of operations that would allow theft to occur w/ callback tokens