### PR TITLE
refactor: drop poetry and use newer package manifest loader

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -33,6 +33,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: ApeWorX/github-action@v3
+        with:
+          python-version: "3.11"
       - run: ape compile --force --size
       # Upload ape build files for testing
       - uses: actions/upload-artifact@v4
@@ -52,6 +54,8 @@ jobs:
       - uses: actions/checkout@v4
       - uses: foundry-rs/foundry-toolchain@v1
       - uses: ApeWorX/github-action@v3
+        with:
+          python-version: "3.11"
       # Ape-built artifacts used for testing
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -57,7 +57,6 @@ jobs:
         with:
           name: ape-build-folder
           path: .build/
-      # TODO: Until `ApeWorX/github-action` supports poetry install
       - run: pip install .
       - run: ape test -s
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
 # Ape stuff
 .build/
 .cache/
-sdk/py/apepay/manifest.json
+
+# setuptools-scm
+sdk/py/apepay/version.py
 
 # Python
 .env

--- a/contracts/Validator.json
+++ b/contracts/Validator.json
@@ -1,0 +1,14 @@
+[
+  {
+    "type": "function",
+    "name": "validate",
+    "stateMutability": "nonpayable",
+    "inputs": [
+      { "name": "creator", "type": "address" },
+      { "name": "token", "type": "address" },
+      { "name": "amount_per_second", "type": "uint256" },
+      { "name": "reason", "type": "bytes" }
+    ],
+    "outputs": [{ "name": "max_stream_life", "type": "uint256" }]
+  }
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,8 @@ requires-python = ">=3.11,<4"
 dependencies = [
     "eth-ape>=0.8,<1",
     "pydantic>=2.7,<3",
+    # NOTE: Pinning issue w/ Ape
+    "eth-typing<5",
 ]
 
 [project.optional-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,30 +1,48 @@
-[tool.poetry]
+[build-system]
+requires = [ "setuptools>=64", "setuptools_scm>=8" ]
+build-backend = "setuptools.build_meta"
+
+[project]
 name = "apepay"
-version = "0.2.2"
+dynamic = [ "version" ]
 description = "Python SDK for ApePay"
-authors = ["ApeWorX LTD <admin@apeworx.io>"]
-license = "Apache 2.0"
+authors = [
+  {name = "ApeWorX LTD", email = "admin@apeworx.io"},
+]
+license = { text = "Apache 2.0" }
 readme = "README.md"
-include = ["sdk/py/apepay/manifest.json"]
-packages = [
-    { include = "apepay", from = "sdk/py" },
+requires-python = ">=3.11,<4"
+
+dependencies = [
+    "eth-ape>=0.8,<1",
+    "pydantic>=2.7,<3",
 ]
 
-[tool.poetry.dependencies]
-python = ">=3.10,<4"
-eth-ape = "^0.8.13"
-pydantic = "^2.6.4"
-silverback = "^0.5.5"
+[project.optional-dependencies]
+bot = [
+    "silverback>=0.5,<1",
+]
+lint = [
+    "black",
+    "isort",
+    "mypy",
+]
+test = [
+    "ape-foundry",
+]
+dev = [
+    "apepay[bot,lint,test]"
+]
 
-[tool.poetry.group.test.dependencies]
-ape-foundry = "^0.8.0"
+[tool.setuptools.packages.find]
+where = [ "sdk/py" ]
 
-[tool.poetry.group.dev.dependencies]
-black = "^24.4.2"
+[tool.setuptools.package-data]
+apepay = [ "manifest.json", "py.typed" ]
 
-[build-system]
-requires = ["poetry-core"]
-build-backend = "poetry.core.masonry.api"
+[tool.setuptools_scm]
+# NOTE: Config entry needed for this plugin to function
+version_file = "sdk/py/apepay/version.py"
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,4 +38,4 @@ force_grid_wrap = 0
 include_trailing_comma = true
 multi_line_output = 3
 use_parentheses = true
-src_paths = ["scripts", "tests", "apepay"]
+src_paths = ["scripts", "tests", "sdk/py/apepay"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ build-backend = "poetry.core.masonry.api"
 
 [tool.black]
 line-length = 100
-target-version = ['py310']
+target-version = [ "py311" ]
 include = '\.pyi?$'
 exclude = 'node_modules|migrations|build/|buck-out/|dist/|_build/|\.git/|\.hg/|\.mypy_cache/|\.tox/|\.venv/'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,6 @@ apepay = [ "manifest.json", "py.typed" ]
 
 [tool.setuptools_scm]
 # NOTE: Config entry needed for this plugin to function
-version_file = "sdk/py/apepay/version.py"
 
 [tool.black]
 line-length = 100

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -6,6 +6,7 @@ from datetime import timedelta
 
 import click
 from ape.cli import ConnectedProviderCommand, ape_cli_context
+
 from apepay import StreamManager
 
 

--- a/scripts/manage.py
+++ b/scripts/manage.py
@@ -1,7 +1,8 @@
 import click
+from ape.cli import ConnectedProviderCommand, account_option, network_option
 from ape.types import AddressType
 from ape_ethereum import multicall
-from ape.cli import ConnectedProviderCommand, network_option, account_option
+
 from apepay import StreamManager
 
 

--- a/sdk/py/apepay/daemon.py
+++ b/sdk/py/apepay/daemon.py
@@ -5,8 +5,9 @@ from enum import Enum
 
 import click
 from ape.types import AddressType
-from apepay import Stream, StreamManager
 from silverback import SilverbackApp
+
+from apepay import Stream, StreamManager
 
 from .settings import Settings
 

--- a/sdk/py/apepay/manifest.json
+++ b/sdk/py/apepay/manifest.json
@@ -1,0 +1,1 @@
+../../../.build/__local__.json

--- a/sdk/py/apepay/package.py
+++ b/sdk/py/apepay/package.py
@@ -1,0 +1,8 @@
+from importlib import resources
+
+from ape.managers.project import ProjectManager
+
+root = resources.files(__package__)
+
+with resources.as_file(root.joinpath("manifest.json")) as manifest_json_file:
+    MANIFEST = ProjectManager.from_manifest(manifest_json_file)

--- a/sdk/py/apepay/settings.py
+++ b/sdk/py/apepay/settings.py
@@ -1,8 +1,9 @@
 from datetime import timedelta
 from typing import Any
 
-from apepay.utils import time_unit_to_timedelta
 from pydantic import BaseSettings, validator
+
+from apepay.utils import time_unit_to_timedelta
 
 
 class Settings(BaseSettings):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
+
 from apepay import StreamManager
+
 
 @pytest.fixture(scope="session")
 def owner(accounts):

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -1,7 +1,8 @@
 from datetime import datetime, timedelta
-import ape
 
+import ape
 import pytest
+
 from apepay import exceptions as apepay_exc
 
 

--- a/tests/test_stream.py
+++ b/tests/test_stream.py
@@ -40,7 +40,9 @@ def test_add_rm_tokens(stream_manager, owner, tokens, create_token):
 
 @pytest.fixture(scope="session")
 def create_stream(stream_manager, payer, MIN_STREAM_LIFE):
-    def create_stream(token=None, amount_per_second=None, sender=None, allowance=(2**256-1), **extra_args):
+    def create_stream(
+        token=None, amount_per_second=None, sender=None, allowance=(2**256 - 1), **extra_args
+    ):
         if amount_per_second is None:
             # NOTE: Maximum amount we can afford to send (using 1 hr pre-allocation)
             amount_per_second = token.balanceOf(sender or payer) // MIN_STREAM_LIFE
@@ -77,7 +79,7 @@ def test_create_stream(chain, payer, token, create_stream, MIN_STREAM_LIFE, extr
     with pytest.raises(apepay_exc.StreamLifeInsufficient):
         create_stream(token, allowance=0, **extra_args)
 
-    amount_per_second = (token.balanceOf(payer) // MIN_STREAM_LIFE)
+    amount_per_second = token.balanceOf(payer) // MIN_STREAM_LIFE
 
     with pytest.raises(apepay_exc.StreamLifeInsufficient):
         # NOTE: Performs approval


### PR DESCRIPTION
### What I did

Was a little annoyed using poetry, this refactors back to using it with standard format tools (also works w/ `uv pip`)