### PR TITLE
feat(py-sdk): factory

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -16,13 +16,17 @@ ethereum:
 
 deployments:
   ethereum:
-    sepolia: &chaosnet
-      # NOTE: Deployed with salt=`ApePay v0.1`
+    sepolia: &releases
       - contract_type: StreamFactory
         address: 0x92823EB2DB42b8df354EDB5A1FB3668057e2935D
+        salt: "ApePay v0.3"
+
       - contract_type: StreamManager
-        address: 0x3543faeeddb7babcbbb216b3627f9c5e0c39ce41
+        address: 0x6A1aa538ebB85Fd98655eCEe5EaB7D9cb3cbCD2B
+        salt: "ApePay v0.3"
+        blueprint: true
+
   arbitrum:
-    mainnet: *chaosnet
+    mainnet: *releases
   optimism:
-    mainnet: *chaosnet
+    mainnet: *releases

--- a/bots/example.py
+++ b/bots/example.py
@@ -37,14 +37,12 @@ async def grant_product(stream):
 async def update_product_funding(stream):
     # NOTE: properties of stream have changed, you may not need to handle this, but typically you
     #       would want to update `stream.time_left` in db for use in user Stream life notifications
-    db[stream.creator].pop(stream.stream_id)
-    db[stream.creator].insert(stream.stream_id, stream)
+    db[stream.creator][stream.stream_id] = stream
     return stream.time_left
 
 
 @sm.on_stream_cancelled(app)
 async def revoke_product(stream):
     print(f"unprovisioning product for {stream.creator}")
-    db[stream.creator].pop(stream.stream_id)
-    db[stream.creator].insert(stream.stream_id, None)
+    db[stream.creator][stream.stream_id] = None
     return stream.time_left

--- a/sdk/py/apepay/__init__.py
+++ b/sdk/py/apepay/__init__.py
@@ -1,3 +1,4 @@
+from .factory import StreamFactory, releases
 from .manager import StreamManager
 from .streams import Stream
 from .validators import Validator
@@ -8,6 +9,8 @@ Validator.model_rebuild()
 
 __all__ = [
     Stream.__name__,
+    StreamFactory.__name__,
     StreamManager.__name__,
     Validator.__name__,
+    "releases",
 ]

--- a/sdk/py/apepay/exceptions.py
+++ b/sdk/py/apepay/exceptions.py
@@ -9,6 +9,13 @@ class ApePayException(Exception):
     pass
 
 
+class NoFactoryAvailable(ApePayException, RuntimeError):
+    def __init__(self):
+        super().__init__(
+            "No deployment of 'StreamFactory' on this chain, please use an explicit address."
+        )
+
+
 class MissingCreationReceipt(ApePayException, NotImplementedError):
     def __init__(self):
         super().__init__("Missing creation transaction for stream. Functionality unavailabie.")

--- a/sdk/py/apepay/factory.py
+++ b/sdk/py/apepay/factory.py
@@ -1,0 +1,58 @@
+from typing import Any
+
+from ape.contracts import ContractInstance
+from ape.types import AddressType, BaseInterfaceModel
+from pydantic import field_validator
+
+from .exceptions import NoFactoryAvailable
+from .manager import StreamManager
+from .package import MANIFEST
+
+
+class StreamFactory(BaseInterfaceModel):
+    address: AddressType
+
+    def __init__(self, address=None, /, *args, **kwargs):
+        if address is not None:
+            kwargs["address"] = address
+
+        elif len(MANIFEST.StreamFactory.deployments) == 0:
+            raise NoFactoryAvailable()
+
+        else:
+            kwargs["address"] = MANIFEST.StreamFactory.deployments[-1]
+
+        super().__init__(*args, **kwargs)
+
+    def __hash__(self) -> int:
+        return self.address.__hash__()
+
+    @field_validator("address", mode="before")
+    def normalize_address(cls, value: Any) -> AddressType:
+        return cls.conversion_manager.convert(value, AddressType)
+
+    @property
+    def contract(self) -> ContractInstance:
+        return MANIFEST.StreamFactory.at(self.address)
+
+    def get_deployment(self, deployer: Any) -> StreamManager:
+        # TODO: Add product selection to the factory using `product=` kwarg (defaults to empty)
+        return StreamManager(self.contract.deployments(deployer))
+
+
+class Releases:
+    def __getitem__(self, release: int) -> StreamFactory:
+        if (
+            len(MANIFEST.StreamFactory.deployments) < release
+            or len(MANIFEST.StreamFactory.deployments) == 0
+        ):
+            raise IndexError("release index out of range") from NoFactoryAvailable()
+
+        return StreamFactory(MANIFEST.StreamFactory.deployments[release])
+
+    @property
+    def latest(self) -> StreamFactory:
+        return StreamFactory()
+
+
+releases = Releases()


### PR DESCRIPTION
### What I did

requires: #110 

Makes it much easier to use this in a silverback app context by letting you do something like this:

```py
import apepay

sm = apepay.releases.latest.get_deployment("product-owner.eth")
# or, if there have been multiple deployed versions of ApePay in use for a given product
managers = [r.get_deployment("product-owner.eth") for r in apepay.releases]
```

Please note that a use should add this section to their `ape-config.yaml` when running the bot (at least until we figure out how to bundle it with the distributed manifest in the package release process)

### How I did it

Using `deployments` w/ network autodetection

### How to verify it

Use it locally

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] New test cases have been added
- [ ] Documentation has been updated
