### PR TITLE
fix: package-name was not a valid EIP-2678 package-name

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,8 +35,10 @@ apepay = ["manifest.json", "py.typed"]
 [tool.setuptools_scm]
 # NOTE: Config entry needed for this plugin to function
 
+# NOTE: Can delete this once https://github.com/ApeWorX/ape/pull/2461
+#   is available.
 [tool.ape]
-name = "ApePay"
+name = "apepay"
 
 plugins = [
     { name = "arbitrum" },


### PR DESCRIPTION
### What I did

EIP-2678 says "ApePay"  is an invalid package name because of the upper case letters.

### How I did it

<!-- Discuss the thought process behind the change -->

### How to verify it

<!-- Discuss methods to verify the change -->

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [ ] All changes are completed
- [ ] Change is covered in tests
- [ ] Documentation is complete
