### PR TITLE
fix(bot): taskiq parsing

### DIFF
--- a/contracts/test/TestToken.vy
+++ b/contracts/test/TestToken.vy
@@ -1,4 +1,4 @@
-# pragma version ^0.4
+# pragma version 0.4.0
 # TODO: Replace w/ Snekmate
 totalSupply: public(uint256)
 balanceOf: public(HashMap[address, uint256])

--- a/contracts/test/TestValidator.vy
+++ b/contracts/test/TestValidator.vy
@@ -1,4 +1,4 @@
-# pragma version ^0.4
+# pragma version 0.4.0
 from ethereum.ercs import IERC20
 
 from .. import Validator

--- a/contracts/validators/Allowlist.vy
+++ b/contracts/validators/Allowlist.vy
@@ -1,3 +1,4 @@
+# pragma version 0.4.0
 from ethereum.ercs import IERC20
 
 from .. import Validator

--- a/contracts/validators/Denylist.vy
+++ b/contracts/validators/Denylist.vy
@@ -1,3 +1,4 @@
+# pragma version 0.4.0
 from ethereum.ercs import IERC20
 
 from .. import StreamManager

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10,<4"
 dependencies = ["eth-ape>=0.8.24,<1", "pydantic>=2.7,<3"]
 
 [project.optional-dependencies]
-bot = ["silverback>=0.5,<1"]
+bot = ["silverback>=0.7.13,<1"]
 lint = [
   "flake8",
   "black",

--- a/sdk/py/apepay/manager.py
+++ b/sdk/py/apepay/manager.py
@@ -224,7 +224,6 @@ class StreamManager(BaseInterfaceModel):
         def decorator(f):
 
             @app.on_(container)
-            @wraps(f)
             async def inner(log, **dependencies):
                 result = f(Stream(manager=self, id=log.stream_id), **dependencies)
 
@@ -233,6 +232,8 @@ class StreamManager(BaseInterfaceModel):
 
                 return result
 
+            # NOTE: Make sure to retain the same name as the underlying task
+            inner.__name__ = f.__name__
             return inner
 
         return decorator


### PR DESCRIPTION
### What I did

Discovered new TaskIQ version runs into a parsing bug:

```
Can't parse argument 0 for task create_clusters_from_stream. Reason: 1 validation error for Stream
    Input should be a valid dictionary or instance of Stream [type=model_type, input_value=<StreamCreated stream_id=...d30c179d714a72bf2529a']>, input_type=ContractLog]
```

### How I did it

`functools.wraps` also takes `__annotations__` along for the ride, which TaskIQ is using

### How to verify it

Ran this locally, works

### Checklist

<!-- All PRs must complete the following checklist before being merged -->

- [x] All changes are completed
~~- [ ] Change is covered in tests~~
~~- [ ] Documentation is complete~~
